### PR TITLE
标点与curl命令修改

### DIFF
--- a/arm_install.sh
+++ b/arm_install.sh
@@ -16,9 +16,9 @@ echo "11: zhejiang_qiye_sxplugin.so"
 echo "12: zhejiang_xiaoyuan_sxplugin.so"  
 echo "请在下方空白处输入编号数字并回车以确认："
 echo "或者ctrl+c退出"
-echo "下载tar集合“
-curl -L https://github.com/xratzh/hiwifi-netkeeper/releases/download/v1.0/arm2.4.7.tar -o arm2.4.7.tar
-tar –xvf arm2.4.7.tar
+echo "下载tar集合"
+curl -Lk https://github.com/xratzh/hiwifi-netkeeper/releases/download/v1.0/arm2.4.7.tar -o arm2.4.7.tar
+tar -xvf arm2.4.7.tar
 read so
 if [ $so = 1 ]
 then

--- a/hiwifi_install.sh
+++ b/hiwifi_install.sh
@@ -16,9 +16,9 @@ echo "11: zhejiang_qiye_sxplugin.so"
 echo "12: zhejiang_xiaoyuan_sxplugin.so"  
 echo "请在下方空白处输入编号数字并回车以确认："
 echo "或者ctrl+c退出"
-echo "下载tar集合“
-curl -L https://github.com/xratzh/hiwifi-netkeeper/releases/download/v1.0/mipsel2.4.5.tar -o mipsel2.4.5.tar
-tar –xvf mipsel2.4.5.tar
+echo "下载tar集合"
+curl -Lk https://github.com/xratzh/hiwifi-netkeeper/releases/download/v1.0/mipsel2.4.5.tar -o mipsel2.4.5.tar
+tar -xvf mipsel2.4.5.tar
 read so
 if [ $so = 1 ]
 then


### PR DESCRIPTION
19行echo使用了右引号使用了中文引号，导致执行失败。修改为英文引号。
20行curl无法通过https下载，添加 -k 后成功下载。-k/--insecure 允许不使用证书到SSL站点。
21行-符号使用了全角，导致解压失败。修改为半角。